### PR TITLE
Remove dependency on future

### DIFF
--- a/ravenpackapi/models/results.py
+++ b/ravenpackapi/models/results.py
@@ -1,7 +1,7 @@
 import json
 from collections import OrderedDict
 
-from past.builtins import basestring
+from six import string_types, binary_type
 
 from ravenpackapi.models.fields import ANALYTICS_FIELDS_SET, FIELD_MAP, ANALYTICS_FIELDS
 
@@ -32,7 +32,7 @@ class Results(object):
 
 class Result(object):
     def __init__(self, record):
-        if isinstance(record, basestring):
+        if isinstance(record, string_types) or isinstance(record, binary_type):
             self.data = json.loads(record)
         else:
             self.data = record

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests[security]
-future
 six
 python-dateutil
 retry

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,5 @@ setup(
     ],
 
     keywords='python analytics api rest news data',
-    install_requires=['requests[security]', 'future', 'python-dateutil', 'six', 'retry'],
+    install_requires=['requests[security]', 'python-dateutil', 'six', 'retry'],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ toxworkdir = {homedir}/.tox/ravenpackapi
 deps =
 	pytest
 	pytest-xdist
-	future
 	python-dateutil
 	requests
 commands = pytest -n 4


### PR DESCRIPTION
`from past.builtins import basestring` causes `DeprecationWarning`
https://github.com/PythonCharmers/python-future/issues/551

I believe this alternative using `six` should behave identically.

On python3 `past.builtins.basestring` is equivalent to `(bytes, str)`:
https://github.com/PythonCharmers/python-future/blob/80523f383fbba1c6de0551e19d0277e73e69573c/src/past/types/basestring.py#L26

On python2, it is the built in `basestring`:
https://github.com/PythonCharmers/python-future/blob/80523f383fbba1c6de0551e19d0277e73e69573c/src/past/builtins/__init__.py#L52

`six.string_types` is either `(basestring, )` or `(str, )`:
https://six.readthedocs.io/#six.string_types

`six.binary_type` is either `str` or `bytes`:
https://six.readthedocs.io/#six.binary_type