### PR TITLE
Fix creating EDGE dataset without product attribute specified

### DIFF
--- a/ravenpackapi/examples/edge_entity_reference_filtered.py
+++ b/ravenpackapi/examples/edge_entity_reference_filtered.py
@@ -9,6 +9,7 @@ that the files for EDGE are way bigger (in the order of GBs). This script helps
 you get those mappings for the entities you are interested into, without having
 to download all the rest.
 """
+
 import csv
 
 from ravenpackapi import RPApi

--- a/ravenpackapi/examples/ravenpack_annotations_batch.py
+++ b/ravenpackapi/examples/ravenpack_annotations_batch.py
@@ -3,6 +3,7 @@ Example to upload a batch of files and get the analytics results in a thread poo
 Note: this example requires the "futures" package in python 2.7,
 or python 3.2+
 """
+
 import glob
 import os
 from concurrent.futures.thread import ThreadPoolExecutor

--- a/ravenpackapi/models/dataset.py
+++ b/ravenpackapi/models/dataset.py
@@ -65,11 +65,9 @@ class Dataset(object):
 
         self.uuid = uuid
 
-        # If the product is not specified, we assume it is RPA
-        # unless the uuid is specified, in which case we'll ask the server
         self.product = product
-        if self.product is None and self.uuid is None:
-            self.product = "RPA"
+        if self.product is None and self.uuid is None and self.api is not None:
+            self.product = self.api.product
 
         self.name = name
         self.description = description

--- a/ravenpackapi/tests/unit/models/test_dataset.py
+++ b/ravenpackapi/tests/unit/models/test_dataset.py
@@ -5,14 +5,14 @@ from ravenpackapi.models.dataset import Dataset
 
 class TestDataset:
     def test_create_rpa_dataset(self, fake_api):
-        dataset = Dataset(api=fake_api, name="test")
+        dataset = Dataset(product="rpa", api=fake_api, name="test")
         assert dataset.name == "test"
         assert dataset.api == fake_api
-        assert dataset.product == "RPA"
+        assert dataset.product == "rpa"
         dataset.save()
         assert fake_api.datasets["1"] == {
             "uuid": "1",
-            "product": "RPA",
+            "product": "rpa",
             "product_version": "1.0",
             "name": "test",
         }
@@ -30,13 +30,18 @@ class TestDataset:
             "name": "test",
         }
 
-    def test_create_dataset_with_default_product(self, fake_api):
+    @pytest.mark.parametrize(
+        "product",
+        ["rpa", "edge"],
+    )
+    def test_create_dataset_with_default_product(self, product):
+        fake_api = FakeAPI(product=product)
         dataset = Dataset(api=fake_api, name="test")
-        assert dataset.product == "RPA"
+        assert dataset.product == product
         dataset.save()
         assert fake_api.datasets["1"] == {
             "uuid": "1",
-            "product": "RPA",
+            "product": product,
             "product_version": "1.0",
             "name": "test",
         }
@@ -117,8 +122,9 @@ class TestDataset:
 
 
 class FakeAPI:
-    def __init__(self):
+    def __init__(self, product="rpa"):
         self.datasets = {}
+        self.product = product
 
     def request(self, endpoint, method="get", json=None):
         if method == "post":


### PR DESCRIPTION
Requesting a creation of a dataset to the EDGE `RPApi` would fail if the `Dataset` had no `product` specified:

```python

import os
 
from ravenpackapi import Dataset, RPApi
 
if __name__ == "__main__":
    api = RPApi(api_key=os.getenv("RP_API_KEY"), product="edge")
 
    entity_relevance = "relevance"  # For RPA
    entity_relevance = "entity_relevance"  # For EDGE
 
    ds = api.create_dataset(
        Dataset(
            name="New Dataset",
            filters={entity_relevance: {"$gte": 90}},
        )
    )
 
    print("Dataset created", ds)
```

Would return:

```
Error calling the API, we tried: curl -X POST -H 'API_KEY:CMO2m4xx1bzcA5dU89CPuV' -d '{"product": "RPA", "product_version": "1.0", "name": "New Dataset", "filters": {"entity_relevance": {"$gte": 90}}}' 'https://api-edge.ravenpack.com/1.0/datasets'
Traceback (most recent call last):
  File "/home/mdagostino/workspace/python-api/pcp-13076.py", line 11, in <module>
    ds = api.create_dataset(
  File "/home/mdagostino/workspace/python-api/ravenpackapi/core.py", line 160, in create_dataset
    new_dataset.save()
  File "/home/mdagostino/workspace/python-api/ravenpackapi/exceptions.py", line 64, in decorated_func
    return func(instance, *args, **kwargs)
  File "/home/mdagostino/workspace/python-api/ravenpackapi/models/dataset.py", line 207, in save
    response = self.api.request(endpoint=endpoint, json=data, method=method)
  File "/home/mdagostino/workspace/python-api/ravenpackapi/core.py", line 123, in request
    raise get_exception(response)
ravenpackapi.exceptions.APIException: Got an error 400: body was '{"endpoint":"datasets","errors":[{"type":"ValidationError","reason":"Field 'product' must be 'edge'","parameter_name":"product","value":"RPA"}]}'
```

Now this workflow works as expected.

One downside is that it's now possible for a `Dataset` object to have a `None` product.