### PR TITLE
Remove dependency on retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## UNRELEASED
 
+### Changed
+
+- Removed the dependency on the library `retry` (and the indirect dependency on
+  `py`), and replaced it with `tenacity`. This should be transparent.
+
 ## v1.1.4 (2024-02-01)
 
 ### Fixed

--- a/ravenpackapi/tests/unit/upload/test_upload_utils.py
+++ b/ravenpackapi/tests/unit/upload/test_upload_utils.py
@@ -1,0 +1,71 @@
+import pytest
+
+from ravenpackapi.exceptions import APIException, APIException425
+from ravenpackapi.upload.upload_utils import retry_on_too_early
+
+
+def get_wait_ranges(retries):
+    """
+    Given a backoff of 2 and a jitter between 1 and 5
+    """
+    max_wait = min_wait = 3
+    for _ in range(retries - 1):
+        min_wait *= 2
+        max_wait *= 2
+        min_wait += 1
+        max_wait += 5
+    return min_wait, max_wait
+
+
+class TestRetryOnTooEarly:
+    def test_fails_if_not_enough_retries(self):
+        eventually_success = EventuallySuccess(num_calls_to_fail=10)
+        with pytest.raises(APIException425):
+            retry_on_too_early(eventually_success, 1, 2, 3, namearg="namevalue")
+        assert eventually_success.num_calls == 10
+        assert eventually_success.calls == [((1, 2, 3), {"namearg": "namevalue"})] * 10
+        3
+        min_wait, max_wait = get_wait_ranges(10)
+        assert min_wait < self.seconds_slept <= max_wait
+
+    def test_succeeds_eventually(self):
+        eventually_success = EventuallySuccess(num_calls_to_fail=9)
+        retry_on_too_early(eventually_success, 1, 2, 3, namearg="namevalue")
+        assert eventually_success.num_calls == 10
+        assert eventually_success.calls == [((1, 2, 3), {"namearg": "namevalue"})] * 10
+
+    def test_only_handles_api_exception_425(self):
+        eventually_success = EventuallySuccess(
+            num_calls_to_fail=100, error_to_raise=APIException
+        )
+        with pytest.raises(APIException):
+            retry_on_too_early(eventually_success, 1, 2, 3, namearg="namevalue")
+        assert eventually_success.num_calls == 1
+        assert eventually_success.calls == [((1, 2, 3), {"namearg": "namevalue"})]
+        assert self.seconds_slept == 0
+
+    @pytest.fixture(autouse=True)
+    def mocked_sleep(self, mocker):
+        self.seconds_slept = 0
+
+        def sleep(seconds):
+            self.seconds_slept += seconds
+
+        time = mocker.patch("retry.api.time")
+        time.sleep.side_effect = sleep
+        return time.sleep
+
+
+class EventuallySuccess:
+    def __init__(self, num_calls_to_fail=0, error_to_raise=APIException425):
+        self.num_calls_to_fail = num_calls_to_fail
+        self.num_calls = 0
+        self.error_to_raise = error_to_raise
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        self.num_calls += 1
+        if self.num_calls <= self.num_calls_to_fail:
+            raise self.error_to_raise
+        return self.num_calls

--- a/ravenpackapi/tests/unit/upload/test_upload_utils.py
+++ b/ravenpackapi/tests/unit/upload/test_upload_utils.py
@@ -4,19 +4,6 @@ from ravenpackapi.exceptions import APIException, APIException425
 from ravenpackapi.upload.upload_utils import retry_on_too_early
 
 
-def get_wait_ranges(retries):
-    """
-    Given a backoff of 2 and a jitter between 1 and 5
-    """
-    max_wait = min_wait = 3
-    for _ in range(retries - 1):
-        min_wait *= 2
-        max_wait *= 2
-        min_wait += 1
-        max_wait += 5
-    return min_wait, max_wait
-
-
 class TestRetryOnTooEarly:
     def test_fails_if_not_enough_retries(self):
         eventually_success = EventuallySuccess(num_calls_to_fail=10)
@@ -25,7 +12,7 @@ class TestRetryOnTooEarly:
         assert eventually_success.num_calls == 10
         assert eventually_success.calls == [((1, 2, 3), {"namearg": "namevalue"})] * 10
         3
-        min_wait, max_wait = get_wait_ranges(10)
+        min_wait, max_wait = 3 * 2 ** 9, 3 * 2 ** 10
         assert min_wait < self.seconds_slept <= max_wait
 
     def test_succeeds_eventually(self):
@@ -51,7 +38,7 @@ class TestRetryOnTooEarly:
         def sleep(seconds):
             self.seconds_slept += seconds
 
-        time = mocker.patch("retry.api.time")
+        time = mocker.patch("tenacity.nap.time")
         time.sleep.side_effect = sleep
         return time.sleep
 

--- a/ravenpackapi/upload/upload_utils.py
+++ b/ravenpackapi/upload/upload_utils.py
@@ -1,6 +1,11 @@
 import logging
 
-from retry.api import retry_call
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
 
 from ravenpackapi.exceptions import APIException425
 
@@ -8,15 +13,17 @@ logger = logging.getLogger("ravenpack.upload.retry")
 
 
 def retry_on_too_early(func, *args, **kwargs):
-    response = retry_call(
-        func,
-        fargs=args,
-        fkwargs=kwargs,
-        exceptions=(APIException425,),
-        delay=3,
-        backoff=2,
-        jitter=(1, 5),
-        tries=10,
-        logger=logger,
-    )
-    return response
+    """
+    Retry a function that may raise a 425 API exception.
+
+    Note: This was originally implemented using the library "retry" and migrated
+    to tenacity. It should not be used in new code, as the proper way to do this
+    using tenacity is to decorate the funciton with @retry.
+    """
+    wrapped_func = retry(
+        retry=retry_if_exception_type(APIException425),
+        wait=wait_exponential_jitter(initial=3, exp_base=2, jitter=5),
+        stop=stop_after_attempt(10),
+        reraise=True,
+    )(func)
+    return wrapped_func(*args, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests[security]
 six
 python-dateutil
-retry
+tenacity

--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,5 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     keywords="python analytics api rest news data",
-    install_requires=["requests[security]", "python-dateutil", "six", "retry"],
+    install_requires=["requests[security]", "python-dateutil", "six", "tenacity"],
 )


### PR DESCRIPTION
This PR fixes #18, replacing the library `retry` with `tenacity`, since `retry` (unnecessarily) depended on `py`.
Note that I tried to isolate the change to one module, but the proper way of using `tenacity` is decorating the functions that do API calls instead of calling `retry_on_too_early` so we may need a refactor of the code at some point.